### PR TITLE
set session from URL hash and clean up

### DIFF
--- a/src/app/auth/reset-password/page.tsx
+++ b/src/app/auth/reset-password/page.tsx
@@ -1,78 +1,101 @@
-'use client';
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
-import Button from '@/src/components/Button';
-import { useAuth } from '@/src/contexts/AuthContext';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
+"use client";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import Button from "@/src/components/Button";
+import { useAuth } from "@/src/contexts/AuthContext";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 import {
   updatePasswordSchema,
   type UpdatePasswordFormData,
 } from "@/src/utils/validations/auth";
+import { supabase } from "@/src/lib/supabaseClient";
 
 export default function ResetPasswordPage() {
-	const router = useRouter();
-	const { updatePassword } = useAuth();
-	const [message, setMessage] = useState('');
+  const router = useRouter();
+  const { updatePassword, session } = useAuth();
+  const [message, setMessage] = useState("");
+  const [initializing, setInitializing] = useState(true);
 
-	const {
-		register,
-		handleSubmit,
-		formState: { errors },
-	} = useForm<UpdatePasswordFormData>({
-		resolver: zodResolver(updatePasswordSchema),
-		defaultValues: {
-			password: '',
-			confirmPassword: '',
-		},
-	});
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<UpdatePasswordFormData>({
+    resolver: zodResolver(updatePasswordSchema),
+    defaultValues: {
+      password: "",
+      confirmPassword: "",
+    },
+  });
 
-	async function handleSubmitForm(data: UpdatePasswordFormData) {
-		const { error } = await updatePassword(data.password);
-		
-		if (error) {
-			setMessage(error.message);
-			return;
-		}
+  useEffect(() => {
+    async function initSessionFromUrl() {
+      const hash = window.location.hash;
+      if (hash) {
+        const params = new URLSearchParams(hash.slice(1));
+        const access_token = params.get("access_token");
+        const refresh_token = params.get("refresh_token");
 
-		router.push('/');
-	}
+        if (access_token && refresh_token) {
+          await supabase.auth.setSession({ access_token, refresh_token });
+          window.history.replaceState(null, "", window.location.pathname);
+        }
+      }
+      setInitializing(false);
+    }
 
-	return (
-		<main className="h-[100vh] min-h-[700px] flex flex-col items-center justify-center p-6">
-			{message && <p className="text-[var(--danger)]">{message}</p>}
-			<h1 className="pb-8 text-center">Reset Password</h1>
-			<form className="auth-form" onSubmit={handleSubmit(handleSubmitForm)}>
-				<div>
-					<label htmlFor="password">New Password</label>
-					<input
-						type="password"
-						id="password"
-						{...register("password")}
-						required
-					/>
-					<div className="text-[var(--danger)]">
-						{errors.password && <p>{errors.password.message}</p>}
-					</div>
-				</div>
-				<div>
-					<label htmlFor="confirmPassword">Confirm Password</label>
-					<input
-						type="password"
-						id="confirmPassword"
-						{...register("confirmPassword")}
-						required
-					/>
-					<div className="text-[var(--danger)]">
-						{errors.confirmPassword && <p>{errors.confirmPassword.message}</p>}
-					</div>
-				</div>
+    initSessionFromUrl();
+  }, []);
 
-				<Button type="submit" variant="primary">
-					Reset Password
-				</Button>
-			</form>
-		</main>
-	);
+  async function handleSubmitForm(data: UpdatePasswordFormData) {
+    const { error } = await updatePassword(data.password);
+
+    if (error) {
+      setMessage(error.message);
+      return;
+    }
+
+    router.push("/");
+  }
+
+  if (initializing) return <p>Loading...</p>;
+  if (!session) return <p>Invalid or expired session.</p>;
+
+  return (
+    <main className="h-[100vh] min-h-[700px] flex flex-col items-center justify-center p-6">
+      {message && <p className="text-[var(--danger)]">{message}</p>}
+      <h1 className="pb-8 text-center">Reset Password</h1>
+      <form className="auth-form" onSubmit={handleSubmit(handleSubmitForm)}>
+        <div>
+          <label htmlFor="password">New Password</label>
+          <input
+            type="password"
+            id="password"
+            {...register("password")}
+            required
+          />
+          <div className="text-[var(--danger)]">
+            {errors.password && <p>{errors.password.message}</p>}
+          </div>
+        </div>
+        <div>
+          <label htmlFor="confirmPassword">Confirm Password</label>
+          <input
+            type="password"
+            id="confirmPassword"
+            {...register("confirmPassword")}
+            required
+          />
+          <div className="text-[var(--danger)]">
+            {errors.confirmPassword && <p>{errors.confirmPassword.message}</p>}
+          </div>
+        </div>
+
+        <Button type="submit" variant="primary">
+          Reset Password
+        </Button>
+      </form>
+    </main>
+  );
 }
-

--- a/src/app/auth/settings/page.tsx
+++ b/src/app/auth/settings/page.tsx
@@ -11,7 +11,6 @@ import { useAvatar } from "@/src/hooks/useAvatar";
 export default function UpdateUser() {
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
-  const [password, setPassword] = useState("");
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [defaultFirstName, setDefaultFirstName] = useState("");
@@ -102,17 +101,6 @@ export default function UpdateUser() {
       }
     }
 
-    if (password.length > 0) {
-      const { error: updateError } = await supabase.auth.updateUser({
-        password: password,
-      });
-
-      if (updateError) {
-        setError(updateError.message);
-        return;
-      }
-    }
-
     const { error: profileError } = await supabase
       .from("profiles")
       .update({
@@ -128,7 +116,6 @@ export default function UpdateUser() {
     }
 
     setMessage("Details updated.");
-    setPassword("");
     setAvatarFile(null);
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
@@ -212,27 +199,10 @@ export default function UpdateUser() {
         </div>
 
         <div>
-          <label htmlFor="password">Password</label>
-          <div className="relative inline-block">
-            <input
-              placeholder="********"
-              autoComplete="new-password"
-              className={`editInput pr-8 ${
-                password ? "input-filled" : "input-default"
-              }`}
-              id="password"
-              type="password"
-              value="password"
-              onChange={e => setPassword(e.target.value)}
-            />
-            <span className="absolute right-4 top-1/2 -translate-y-1/2 text-[var(--unavailable-text)]">
-              <Pen size={16} strokeWidth={1} />
-            </span>
-          </div>
           {error && <div className="text-[var(--danger)]">{error}</div>}
           {message && <div>{message}</div>}
         </div>
-        {updatedFirstName || updatedLastName || password || avatarFile ? (
+        {updatedFirstName || updatedLastName || avatarFile ? (
           <Button type="submit" variant="primary">
             Update details
           </Button>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -2,53 +2,17 @@
 
 import { createContext, useContext, useEffect, useState } from "react";
 import { supabase } from "@/src/lib/supabaseClient";
-import {
-  Session,
-  User,
-  PostgrestError,
-  AuthError,
-} from "@supabase/supabase-js";
+import { Session, User } from "@supabase/supabase-js";
+import { ProfileProps } from "../types/props";
+import { AuthContextTypeProps } from "../types/props";
 
-interface Profile {
-  first_name: string;
-  last_name: string;
-  avatar_url: string | null;
-}
-
-interface AuthContextType {
-  user: User | null;
-  session: Session | null;
-  loading: boolean;
-  profile: Profile | null;
-  signIn: (
-    email: string,
-    password: string,
-  ) => Promise<{ error: AuthError | null }>;
-  signUp: (
-    email: string,
-    password: string,
-    userData: { first_name: string; last_name: string },
-  ) => Promise<{ error: AuthError | PostgrestError | null }>;
-  signOut: () => Promise<void>;
-  resetPassword: (email: string) => Promise<{ error: AuthError | null }>;
-  updatePassword: (password: string) => Promise<{ error: AuthError | null }>;
-  updateProfile: (data: {
-    first_name?: string;
-    last_name?: string;
-    avatar_url?: string | null;
-  }) => Promise<{ error: PostgrestError | Error | null }>;
-  uploadAvatar: (
-    file: File,
-  ) => Promise<{ url: string | null; error: PostgrestError | Error | null }>;
-}
-
-const AuthContext = createContext<AuthContextType | undefined>(undefined);
+const AuthContext = createContext<AuthContextTypeProps | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
-  const [profile, setProfile] = useState<Profile | null>(null);
+  const [profile, setProfile] = useState<ProfileProps | null>(null);
   const [isInitialized, setIsInitialized] = useState(false);
   const [isInitializing, setIsInitializing] = useState(true);
   const [pendingAuthEvent, setPendingAuthEvent] = useState<{
@@ -101,7 +65,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       event: string,
       currentSession: Session | null,
     ) {
-
       if (currentSession?.access_token) {
         setSession(currentSession);
         setUser(currentSession.user);
@@ -119,7 +82,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange(async (event, currentSession) => {
-
       if (mounted) {
         if (isInitializing) {
           setPendingAuthEvent({ event, session: currentSession });

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -1,6 +1,39 @@
 import { User } from "@supabase/supabase-js";
 import { StaticImageData } from "next/image";
 import { ReactNode } from "react";
+import { Session, PostgrestError, AuthError } from "@supabase/supabase-js";
+
+export interface ProfileProps {
+  first_name: string;
+  last_name: string;
+  avatar_url: string | null;
+}
+export interface AuthContextTypeProps {
+  user: User | null;
+  session: Session | null;
+  loading: boolean;
+  profile: Profile | null;
+  signIn: (
+    email: string,
+    password: string,
+  ) => Promise<{ error: AuthError | null }>;
+  signUp: (
+    email: string,
+    password: string,
+    userData: { first_name: string; last_name: string },
+  ) => Promise<{ error: AuthError | PostgrestError | null }>;
+  signOut: () => Promise<void>;
+  resetPassword: (email: string) => Promise<{ error: AuthError | null }>;
+  updatePassword: (password: string) => Promise<{ error: AuthError | null }>;
+  updateProfile: (data: {
+    first_name?: string;
+    last_name?: string;
+    avatar_url?: string | null;
+  }) => Promise<{ error: PostgrestError | Error | null }>;
+  uploadAvatar: (
+    file: File,
+  ) => Promise<{ url: string | null; error: PostgrestError | Error | null }>;
+}
 
 export interface FunctionalityCardProps {
   src: StaticImageData;


### PR DESCRIPTION
## Task

https://app.clickup.com/t/86c3tjzbw

## What is included in this PR

Parses access_token and refresh_token from the URL hash on initial load
Uses Supabase auth.setSession to restore the user session
Cleans up the URL by removing the hash after session is set
Ensures the app doesn't stay in an "initializing" state after attempting session restoration

## How can we test your branch?
Request a password reset
Reset Password
Login with the new password